### PR TITLE
Add Rust update script for Unix systems

### DIFF
--- a/unix/rust/update_rust.sh
+++ b/unix/rust/update_rust.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rustup update


### PR DESCRIPTION
Adds a simple shell script to update Rust toolchain using rustup on Unix-based systems.