### PR TITLE
Add Claude Code installation scripts for Unix and Windows

### DIFF
--- a/unix/ai/claude_code/install_claude_code.sh
+++ b/unix/ai/claude_code/install_claude_code.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Install Claude Code CLI
+# Reference: https://docs.anthropic.com/en/docs/claude-code/setup
+
+set -e
+
+echo "Installing Claude Code..."
+
+if ! command -v npm &>/dev/null; then
+    echo "Error: npm is not installed. Please install Node.js and npm first."
+    exit 1
+fi
+
+npm install -g @anthropic-ai/claude-code
+
+if [ $? -eq 0 ]; then
+    echo "Claude Code installed successfully!"
+    echo "You can now use 'claude' command."
+else
+    echo "Failed to install Claude Code."
+    exit 1
+fi

--- a/win/powershell/ai/claude_code/install_claude_code.ps1
+++ b/win/powershell/ai/claude_code/install_claude_code.ps1
@@ -1,0 +1,27 @@
+# Install Claude Code CLI
+# Reference: https://docs.anthropic.com/en/docs/claude-code/setup
+
+Write-Host "Installing Claude Code..." -ForegroundColor Green
+
+try {
+    # Check if npm is installed
+    $npmCheck = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCheck) {
+        Write-Host "Error: npm is not installed. Please install Node.js and npm first." -ForegroundColor Red
+        exit 1
+    }
+
+    # Install Claude Code globally
+    npm install -g @anthropic-ai/claude-code
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Claude Code installed successfully!" -ForegroundColor Green
+        Write-Host "You can now use 'claude' command." -ForegroundColor Green
+    } else {
+        Write-Host "Failed to install Claude Code." -ForegroundColor Red
+        exit 1
+    }
+} catch {
+    Write-Host "An error occurred: $_" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
Adds installation scripts for Claude Code CLI on both Unix (macOS/Linux) and Windows platforms. The scripts check for npm availability before attempting to install the @anthropic-ai/claude-code package globally.

## Test plan
- [ ] Test Unix script on macOS
- [ ] Test Unix script on Linux
- [ ] Test Windows PowerShell script on Windows 11
- [ ] Verify npm check works correctly when npm is not installed
- [ ] Verify successful installation when npm is available
- [ ] Confirm `claude` command is available after installation