### PR TITLE
Add PowerShell installation script for macOS

### DIFF
--- a/darwin/powershell/install_powershell.sh
+++ b/darwin/powershell/install_powershell.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Install PowerShell via Homebrew Cask
+# Ref: https://learn.microsoft.com/ja-jp/powershell/scripting/install/installing-powershell-on-macos
+
+set -e
+
+echo "Installing PowerShell via Homebrew Cask..."
+
+# Check if Homebrew is installed
+if ! command -v brew &>/dev/null; then
+    echo "Error: Homebrew is not installed. Please install Homebrew first."
+    exit 1
+fi
+
+# Install PowerShell
+brew install --cask powershell
+
+echo "PowerShell installation completed!"
+echo "You can now run PowerShell with 'pwsh' command."


### PR DESCRIPTION
Adds a macOS installation script for PowerShell via Homebrew Cask. The script includes error handling to check for Homebrew availability before attempting the installation.

## Test plan
- [x] Test script on macOS with Homebrew installed
- [ ] Test script on macOS without Homebrew (should fail gracefully)
- [x] Verify PowerShell is accessible via `pwsh` command after installation
- [x] Confirm script follows project conventions for error handling