### PR TITLE
Add context7 MCP installation scripts for Unix and Windows

### DIFF
--- a/unix/ai/claude_code/mcp/install_context7_mcp.sh
+++ b/unix/ai/claude_code/mcp/install_context7_mcp.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Install context7 MCP server for Claude Code
+# Reference: https://docs.anthropic.com/en/docs/claude-code/mcp
+
+set -e
+
+echo "Installing context7 MCP server..."
+
+# Check if Claude Code is installed
+if ! command -v claude &>/dev/null; then
+    echo "Error: Claude Code is not installed. Please install Claude Code first."
+    echo "Run: ../install_claude_code.sh"
+    exit 1
+fi
+
+# Install context7 MCP server
+claude mcp add -s user context7 -- npx -y @upstash/context7-mcp
+
+if [ $? -eq 0 ]; then
+    echo "context7 MCP server installed successfully!"
+    echo "You can now use context7 to retrieve up-to-date documentation for any library."
+else
+    echo "Failed to install context7 MCP server."
+    exit 1
+fi

--- a/win/powershell/ai/claude_code/mcp/install_context7_mcp.ps1
+++ b/win/powershell/ai/claude_code/mcp/install_context7_mcp.ps1
@@ -1,0 +1,30 @@
+# Install context7 MCP server for Claude Code
+# Reference: https://docs.anthropic.com/en/docs/claude-code/mcp
+
+Write-Host "Installing context7 MCP server..." -ForegroundColor Green
+
+try {
+    # Check if Claude Code is installed
+    $claudeCheck = Get-Command claude -ErrorAction SilentlyContinue
+    if (-not $claudeCheck) {
+        Write-Host "Error: Claude Code is not installed. Please install Claude Code first." -ForegroundColor Red
+        Write-Host "Run: ..\install_claude_code.ps1" -ForegroundColor Yellow
+        exit 1
+    }
+
+    # Install context7 MCP server
+    claude mcp add -s user context7 -- npx -y @upstash/context7-mcp
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "context7 MCP server installed successfully!" -ForegroundColor Green
+        Write-Host "You can now use context7 to retrieve up-to-date documentation for any library." -ForegroundColor Green
+    }
+    else {
+        Write-Host "Failed to install context7 MCP server." -ForegroundColor Red
+        exit 1
+    }
+}
+catch {
+    Write-Host "An error occurred: $_" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
Adds installation scripts for context7 MCP server on both Unix (macOS/Linux) and Windows platforms. The scripts check for Claude Code availability before attempting to install the context7 MCP server via npx.

## Test plan
- [ ] Test Unix script on macOS with Claude Code installed
- [ ] Test Unix script on Linux with Claude Code installed
- [ ] Test Windows PowerShell script on Windows 11 with Claude Code installed
- [ ] Verify Claude Code check works correctly when Claude Code is not installed
- [ ] Verify successful installation when Claude Code is available
- [ ] Confirm context7 MCP server is available in Claude Code after installation