### PR TITLE
Add HackMD CLI installation scripts for hackmd-cli and codimd-cli

### DIFF
--- a/common/hackmd/install_codimd_cli.sh
+++ b/common/hackmd/install_codimd_cli.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Install @hackmd/codimd-cli
+# https://www.npmjs.com/package/@hackmd/codimd-cli
+
+echo "Installing @hackmd/codimd-cli..."
+npm install -g @hackmd/codimd-cli
+
+# Check if installation was successful
+if command -v codimd-cli &>/dev/null; then
+    echo "@hackmd/codimd-cli installed successfully!"
+    # Create config directory if it doesn't exist
+    mkdir -p ~/.codimd
+    # Create empty config file if it doesn't exist
+    if [ ! -f ~/.codimd/config.json ]; then
+        echo '{}' >~/.codimd/config.json
+    fi
+    echo "Config file created at ~/.codimd/config.json"
+else
+    echo "Installation failed!"
+    exit 1
+fi

--- a/common/hackmd/install_hackmd_cli.sh
+++ b/common/hackmd/install_hackmd_cli.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install @hackmd/hackmd-cli
+# https://www.npmjs.com/package/@hackmd/hackmd-cli
+
+echo "Installing @hackmd/hackmd-cli..."
+npm install -g @hackmd/hackmd-cli
+
+# Check if installation was successful
+if command -v hackmd-cli &>/dev/null; then
+    echo "@hackmd/hackmd-cli installed successfully!"
+    echo "Version: $(hackmd-cli --version)"
+else
+    echo "Installation failed!"
+    exit 1
+fi


### PR DESCRIPTION
Adds installation scripts for two HackMD command-line tools: @hackmd/hackmd-cli and @hackmd/codimd-cli. Both scripts are placed in common/hackmd/ as they are cross-platform npm packages.

## Summary
- Added install_hackmd_cli.sh for @hackmd/hackmd-cli installation
- Added install_codimd_cli.sh for @hackmd/codimd-cli installation  
- codimd-cli script includes automatic config file creation to prevent runtime errors

## Test plan
- [ ] Test install_hackmd_cli.sh installation
  ```bash
  cd common/hackmd
  ./install_hackmd_cli.sh
  hackmd-cli --version
  ```
- [ ] Test install_codimd_cli.sh installation
  ```bash
  cd common/hackmd
  ./install_codimd_cli.sh
  # Verify config file is created
  ls -la ~/.codimd/config.json
  codimd-cli --help
  ```
- [ ] Verify both CLIs work correctly after installation
- [ ] Test on systems without npm installed (should fail gracefully)