### PR TITLE
Update Docker install script to official modern method with Ubuntu/Debian support

### DIFF
--- a/linux/docker/install_docker_debian.sh
+++ b/linux/docker/install_docker_debian.sh
@@ -1,14 +1,52 @@
 #!/bin/bash
 
+set -e
+
+# Reference:
+# - https://docs.docker.com/engine/install/ubuntu/
+# - https://docs.docker.com/engine/install/debian/
+
+# Detect distro (ubuntu or debian)
+. /etc/os-release
+if [[ "$ID" == "ubuntu" || "$ID_LIKE" == *"ubuntu"* ]]; then
+    DISTRO="ubuntu"
+    CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+elif [[ "$ID" == "debian" || "$ID_LIKE" == *"debian"* ]]; then
+    DISTRO="debian"
+    CODENAME="$VERSION_CODENAME"
+else
+    echo "Unsupported distro: $ID" >&2
+    exit 1
+fi
+
+if [[ -z "$CODENAME" ]]; then
+    echo "Failed to detect version codename" >&2
+    exit 1
+fi
+
+echo "Detected distro: $DISTRO ($CODENAME)"
+
+# Clean up old-format Docker repo files
+sudo rm -f /etc/apt/sources.list.d/docker.list /usr/share/keyrings/docker-archive-keyring.gpg
+
 # Set up the repository
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL "https://download.docker.com/linux/${DISTRO}/gpg" -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/${DISTRO}
+Suites: ${CODENAME}
+Components: stable
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
 
 # Install Docker Engine
 sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Manage Docker as a non-root user
-sudo gpasswd -a $USER docker
+sudo gpasswd -a "$USER" docker


### PR DESCRIPTION
Update Docker install script to use the official modern installation method from Docker docs, with automatic Ubuntu/Debian distro detection.

## Summary
- Replaced legacy GPG keyring and apt source format with modern `docker.asc` key and DEB822 `.sources` format
- Added automatic distro detection (Ubuntu/Debian) with codename resolution
- Added cleanup of old-format Docker repo files before setup
- Added `docker-buildx-plugin` and `docker-compose-plugin` to installed packages

## Changes
- `linux/docker/install_docker_debian.sh`: Rewritten to follow current official Docker installation docs for both Ubuntu and Debian

## Test plan
- [x] Test on Ubuntu system: verify distro detection outputs `ubuntu` and correct codename
- [ ] Test on Debian system: verify distro detection outputs `debian` and correct codename
- [ ] Test on unsupported distro: verify script exits with error message
- [x] Verify Docker Engine installs and runs successfully after script execution
- [x] Verify non-root user can run `docker` commands after re-login